### PR TITLE
fix tag name regex match to allow hyphen

### DIFF
--- a/src/helpers/xmlsimpleparser.ts
+++ b/src/helpers/xmlsimpleparser.ts
@@ -139,7 +139,7 @@ export default class XmlSimpleParser {
 						let normalizedContent = content.concat(" ").replace("/", "").replace("\t", " ").replace("\n", " ").replace("\r", " ");
 						let tagName = content.substring(1, normalizedContent.indexOf(" "));
 
-						result = { tagName: /^[a-z0-9\.-_]*$/.test(tagName) ? tagName : undefined, context: undefined };
+						result = { tagName: /^[a-zA-Z0-9_:\.\-]+$/.test(tagName) ? tagName : undefined, context: undefined };
 
 						if (content.lastIndexOf(">") >= content.lastIndexOf("<")) {
 							result.context = "text";


### PR DESCRIPTION
bug: the `\.-_` is chars from dot to underscore.. new regex missing special chars as to specs but should be better