### PR TITLE
Xsd cache load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4238,6 +4238,11 @@
         "vscode-test": "^0.4.1"
       }
     },
+    "vscode-cache": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vscode-cache/-/vscode-cache-0.3.0.tgz",
+      "integrity": "sha1-fMOWZOvZnTcDAwaLibxMlWFGZ8A="
+    },
     "vscode-test": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
   },
   "dependencies": {
     "get-uri": "3.0.2",
-    "sax": "1.2.4"
+    "sax": "1.2.4",
+    "vscode-cache": "^0.3.0"
   },
   "devDependencies": {
     "@types/mocha": "7.0.1",

--- a/src/definitioncontentprovider.ts
+++ b/src/definitioncontentprovider.ts
@@ -11,6 +11,6 @@ export default class XmlDefinitionContentProvider implements vscode.TextDocument
 	async provideTextDocumentContent (uri : vscode.Uri) : Promise<string> {
 		// NOTE: Uri@Windows is normalizing to lower-case (https://vshaxe.github.io/vscode-extern/vscode/Uri.html), using hex
 		const trueUri = Buffer.from(uri.toString(true).replace(`${schemaId}://`, ''), 'hex').toString();
-        return await XsdCachedLoader.loadSchemaContentsFromUri(trueUri);
+        return (await XsdCachedLoader.loadSchemaContentsFromUri(trueUri)).data;
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ export function activate(context: vscode.ExtensionContext): void {
 function loadConfiguration(): void {
 	const section = vscode.workspace.getConfiguration('xmlComplete', null);
 	globalSettings = new XmlCompleteSettings();
+	globalSettings.xsdCachePattern = section.get('xsdCachePattern', undefined);
 	globalSettings.schemaMapping = section.get('schemaMapping', []);
 	globalSettings.formattingStyle = section.get('formattingStyle', "singleLineAttributes");
 }

--- a/src/helpers/xsdcachedloader.ts
+++ b/src/helpers/xsdcachedloader.ts
@@ -15,8 +15,8 @@ export default class XsdCachedLoader {
 		XsdCachedLoader.pluginVersion = vscode.extensions.getExtension('rogalmic.vscode-xml-complete')?.packageJSON.version as string;
 	}
 
-	public static async loadSchemaContentsFromUri(schemaLocationUri: string, formatXsd = true): Promise<{data:string, cached:boolean}> {
-		let cacheLocally = schemaLocationUri.startsWith("https://raw.githubusercontent.com/rogalmic/vscode-xml-complete/master");
+	public static async loadSchemaContentsFromUri(schemaLocationUri: string, formatXsd = true, xsdCachePattern: string | undefined = undefined): Promise<{data:string, cached:boolean}> {
+		let cacheLocally = xsdCachePattern && (schemaLocationUri.match(xsdCachePattern) != null)
 		let schemaLocationUriVersioned = schemaLocationUri + "?v=" + this.pluginVersion;
 
 		if (cacheLocally)

--- a/src/helpers/xsdcachedloader.ts
+++ b/src/helpers/xsdcachedloader.ts
@@ -42,6 +42,16 @@ export default class XsdCachedLoader {
 		if (result !== undefined) {
 			if (cacheLocally)
 			{
+				// purge previous
+				let keys:string[] = this.vscodeCache.keys();
+				let toRemove:string[] = [];
+				keys.forEach(x => {
+					if (x.startsWith(schemaLocationUri))
+					toRemove.push(x);
+				});
+				toRemove.forEach(x => this.vscodeCache.forget(x));
+
+				// add new one
 				this.vscodeCache.put(schemaLocationUriVersioned, result);
 			}
 			return { data:result, cached:false };

--- a/src/helpers/xsdcachedloader.ts
+++ b/src/helpers/xsdcachedloader.ts
@@ -1,11 +1,32 @@
+import * as vscode from 'vscode';
 import XsdLoader from './xsdloader';
 import XmlSimpleParser from './xmlsimpleparser';
+import * as Cache from 'vscode-cache';
 
 export default class XsdCachedLoader {
 
 	private static cachedSchemas : Map<string, string> = new Map<string, string>();
 
-	public static async loadSchemaContentsFromUri(schemaLocationUri: string, formatXsd = true): Promise<string> {
+	private static vscodeCache : Cache;
+	private static pluginVersion : string;
+
+	public static InitVscodeCache(extensionContext: vscode.ExtensionContext) {
+		XsdCachedLoader.vscodeCache = new Cache(extensionContext);
+		XsdCachedLoader.pluginVersion = vscode.extensions.getExtension('rogalmic.vscode-xml-complete')?.packageJSON.version as string;
+	}
+
+	public static async loadSchemaContentsFromUri(schemaLocationUri: string, formatXsd = true): Promise<{data:string, cached:boolean}> {
+		let cacheLocally = schemaLocationUri.startsWith("https://raw.githubusercontent.com/rogalmic/vscode-xml-complete/master");
+		let schemaLocationUriVersioned = schemaLocationUri + "?v=" + this.pluginVersion;
+
+		if (cacheLocally)
+		{
+			if (this.vscodeCache.has(schemaLocationUriVersioned))
+			{
+				let q = this.vscodeCache.get(schemaLocationUriVersioned);
+				return { data:q, cached:true };
+			}
+		}
 		if (!XsdCachedLoader.cachedSchemas.has(schemaLocationUri)) {
 			let content =  await XsdLoader.loadSchemaContentsFromUri(schemaLocationUri);
 
@@ -19,7 +40,11 @@ export default class XsdCachedLoader {
 		const result = XsdCachedLoader.cachedSchemas.get(schemaLocationUri);
 
 		if (result !== undefined) {
-			return result;
+			if (cacheLocally)
+			{
+				this.vscodeCache.put(schemaLocationUriVersioned, result);
+			}
+			return { data:result, cached:false };
 		}
 
 		throw `Cannot get schema contents from '${schemaLocationUri}'`;

--- a/src/linterprovider.ts
+++ b/src/linterprovider.ts
@@ -104,10 +104,11 @@ export default class XmlLinterProvider implements vscode.Disposable {
 
                     try {
                         const xsdUriString = xsdUri.toString(true);
-                        let q = await XsdCachedLoader.loadSchemaContentsFromUri(xsdUriString);
+                        let q = await XsdCachedLoader.loadSchemaContentsFromUri(xsdUriString, true, globalSettings.xsdCachePattern);
                         schemaProperty.xsdContent = q.data;
                         schemaProperty.tagCollection = await XsdParser.getSchemaTagsAndAttributes(schemaProperty.xsdContent, xsdUriString, (u) => xsdFileUris.push({ uri: vscode.Uri.parse(XmlSimpleParser.ensureAbsoluteUri(u, xsdUriString)), parentUri: currentUriPair.parentUri}));
-                        vscode.window.showInformationMessage(`Loaded ` + (q.cached ? '(cache)' : '') + ` ...${xsdUri.toString().substr(xsdUri.path.length - 16)}`);
+                        const s = xsdUri.toString();
+                        vscode.window.showInformationMessage(`Loaded ${q.cached ? '(cache) ' : ''}${s.length>48 ? '...' : ''}${s.substr(Math.max(0, s.length-48))}`);
                     }
                     catch (err) {
                         vscode.window.showErrorMessage(err.toString());

--- a/src/linterprovider.ts
+++ b/src/linterprovider.ts
@@ -17,6 +17,8 @@ export default class XmlLinterProvider implements vscode.Disposable {
         this.schemaPropertiesArray = schemaPropertiesArray;
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
 
+        XsdCachedLoader.InitVscodeCache(extensionContext);
+
         this.documentListener = vscode.workspace.onDidChangeTextDocument(evnt =>
             this.triggerDelayedLint(evnt.document), this, this.extensionContext.subscriptions);
 
@@ -102,9 +104,10 @@ export default class XmlLinterProvider implements vscode.Disposable {
 
                     try {
                         const xsdUriString = xsdUri.toString(true);
-                        schemaProperty.xsdContent = await XsdCachedLoader.loadSchemaContentsFromUri(xsdUriString);
+                        let q = await XsdCachedLoader.loadSchemaContentsFromUri(xsdUriString);
+                        schemaProperty.xsdContent = q.data;
                         schemaProperty.tagCollection = await XsdParser.getSchemaTagsAndAttributes(schemaProperty.xsdContent, xsdUriString, (u) => xsdFileUris.push({ uri: vscode.Uri.parse(XmlSimpleParser.ensureAbsoluteUri(u, xsdUriString)), parentUri: currentUriPair.parentUri}));
-                        vscode.window.showInformationMessage(`Loaded ...${xsdUri.toString().substr(xsdUri.path.length - 16)}`);
+                        vscode.window.showInformationMessage(`Loaded ` + (q.cached ? '(cache)' : '') + ` ...${xsdUri.toString().substr(xsdUri.path.length - 16)}`);
                     }
                     catch (err) {
                         vscode.window.showErrorMessage(err.toString());

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 export class XmlCompleteSettings {
+	xsdCachePattern?: string;
 	schemaMapping: { xmlns: string, xsdUri: string, strict: boolean }[];
 	formattingStyle: "singleLineAttributes" | "multiLineAttributes" | "fileSizeOptimized";
 }


### PR DESCRIPTION
allow to cache xsd already loaded.

- enabled only for xsd with uri starting with `https://raw.githubusercontent.com/rogalmic/vscode-xml-complete/master`
- download first time, then use cached version second times ( it survive between vscode restart thanks to vscode globalStorage in `~/.config/Code/User/globalStorage/state.vscdb` sqlite3 ) . It uses [vscode-cache](https://github.com/Jakobud/vscode-cache) module.

![2021-02-10_23-23](https://user-images.githubusercontent.com/13405008/107586857-10f21600-6c01-11eb-9ecb-a843e41dc6d8.png)

- automatically re-download if plugin version updates and purge previous downloaded xsd from cache
- save bandwidth ( 2th time there is only normal vscode network activity at start )

![image](https://user-images.githubusercontent.com/13405008/107587006-4c8ce000-6c01-11eb-92c9-0bdaec9ee6aa.png)


